### PR TITLE
Add event specific tracking

### DIFF
--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -5,8 +5,12 @@ import { OutboundLink } from "gatsby-plugin-gtag";
 import analyticsEventHandler from "../../utils/analyticsEventHandler";
 import "./LessonButton.scss";
 
-const handleEventClick = path => {
-  analyticsEventHandler("exercise click", path);
+const handleEventClick = (path) => {
+  try {
+    analyticsEventHandler("exercise click", path);
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 export const PureLessonButton = ({ path, data, onClick }) => {
@@ -52,7 +56,7 @@ PureLessonButton.propTypes = {
 
 PureLessonButton.defaultProps = {
   repoName: "awesome-learning",
-  repoOwner: 'wayfair',
+  repoOwner: "wayfair",
   onClick() {}
 };
 export default LessonButton;

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -1,9 +1,17 @@
 import React from "react";
 import { graphql, StaticQuery } from "gatsby";
 import PropTypes from "prop-types";
-import { OutboundLink } from 'gatsby-plugin-gtag'
+import { OutboundLink } from "gatsby-plugin-gtag";
 import "./LessonButton.scss";
 
+const analyiticsEventHandler = (eventCategory = "outbound", eventLabel) => {
+  if (window.gtag) {
+    window.gtag("event", "click", {
+      event_category: eventCategory,
+      event_label: eventLabel
+    });
+  }
+};
 export const PureLessonButton = ({ path, data }) => {
   const { repoOwner } = data.site.siteMetadata;
   const fullPath = `https://codesandbox.io/s/github/${repoOwner}/awesome-learning-exercises/tree/master/${path}?fontsize=14&previewwindow=tests`;

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -2,17 +2,14 @@ import React from "react";
 import { graphql, StaticQuery } from "gatsby";
 import PropTypes from "prop-types";
 import { OutboundLink } from "gatsby-plugin-gtag";
+import analyticsEventHandler from "../../utils/analyticsEventHandler";
 import "./LessonButton.scss";
 
-const analyiticsEventHandler = (eventCategory = "outbound", eventLabel) => {
-  if (window.gtag) {
-    window.gtag("event", "click", {
-      event_category: eventCategory,
-      event_label: eventLabel
-    });
-  }
+const handleEventClick = path => {
+  analyticsEventHandler("exercise click", path);
 };
-export const PureLessonButton = ({ path, data }) => {
+
+export const PureLessonButton = ({ path, data, onClick }) => {
   const { repoOwner } = data.site.siteMetadata;
   const fullPath = `https://codesandbox.io/s/github/${repoOwner}/awesome-learning-exercises/tree/master/${path}?fontsize=14&previewwindow=tests`;
   return (
@@ -21,6 +18,7 @@ export const PureLessonButton = ({ path, data }) => {
       href={fullPath}
       rel="noopener noreferrer"
       target="_blank"
+      onClick={() => onClick(path)}
     >
       Click here to start your exercises!
     </OutboundLink>
@@ -39,14 +37,22 @@ const LessonButton = props => (
         }
       }
     `}
-    render={data => <PureLessonButton data={data} {...props} />}
+    render={data => (
+      <PureLessonButton data={data} {...props} onClick={handleEventClick} />
+    )}
   />
 );
 
 PureLessonButton.propTypes = {
   path: PropTypes.string.isRequired,
   repoName: PropTypes.string,
-  repoOwner: PropTypes.string
+  repoOwner: PropTypes.string.isRequired,
+  onClick: PropTypes.func
 };
 
+PureLessonButton.defaultProps = {
+  repoName: "awesome-learning",
+  repoOwner: 'wayfair',
+  onClick() {}
+};
 export default LessonButton;

--- a/src/components/LessonButton/LessonButton.test.js
+++ b/src/components/LessonButton/LessonButton.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import { OutboundLink } from "gatsby-plugin-gtag";
 import { PureLessonButton } from "./LessonButton";
 
 describe("LessonButton", () => {
@@ -16,11 +17,18 @@ describe("LessonButton", () => {
   };
 
   it("creates a link with the right codesandox url", () => {
-    const wrapper = mount(
-      <PureLessonButton {...props} />
-    );
+    const wrapper = mount(<PureLessonButton {...props} />);
     expect(wrapper.find("a").props().href).toBe(
       "https://codesandbox.io/s/github/wayfair/awesome-learning-exercises/tree/master/data-types/objects?fontsize=14&previewwindow=tests"
     );
+  });
+  it("calls the handler when the outbound link is clicked", () => {
+    const handleClick = jest.fn();
+    const wrapper = mount(
+      <PureLessonButton {...props} onClick={handleClick} />
+    );
+    const link = wrapper.find(OutboundLink);
+    link.simulate("click");
+    expect(handleClick).toHaveBeenCalledWith(props.path);
   });
 });

--- a/src/utils/__tests__/analyticsEventHandler_spect.test.js
+++ b/src/utils/__tests__/analyticsEventHandler_spect.test.js
@@ -1,0 +1,22 @@
+import analyticsEventHandler from "../analyticsEventHandler";
+
+describe("Google analytics event dispatch handler", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it("dispatches an event if the gtag is present", () => {
+    const gtag = jest.fn();
+    window.gtag = gtag;
+    analyticsEventHandler("outboundLink", "forEach exercises");
+    expect(gtag).toBeCalledWith("event", "click", {
+      event_category: "outboundLink",
+      event_label: "forEach exercises"
+    });
+  });
+  it("doesn't dispatch an event if gtag is not present on the window object", () => {
+    delete window.gtag;
+    expect(() =>
+      analyticsEventHandler("outboundLink", "forEach exercises")
+    ).toThrowError("there is no gtag here");
+  });
+});

--- a/src/utils/analyticsEventHandler.js
+++ b/src/utils/analyticsEventHandler.js
@@ -1,0 +1,12 @@
+const analyticsEventHandler = (eventCategory = "outbound", eventLabel) => {
+  if (window.gtag) {
+    window.gtag("event", "click", {
+      event_category: eventCategory,
+      event_label: eventLabel
+    });
+  } else {
+    throw new Error('there is no gtag here')
+  }
+};
+
+export default analyticsEventHandler;

--- a/src/utils/analyticsEventHandler.js
+++ b/src/utils/analyticsEventHandler.js
@@ -1,4 +1,4 @@
-const analyticsEventHandler = (eventCategory = "outbound", eventLabel) => {
+const analyticsEventHandler = (eventCategory = "exercise click", eventLabel) => {
   if (window.gtag) {
     window.gtag("event", "click", {
       event_category: eventCategory,


### PR DESCRIPTION
## Description
We currently have outbound link tracking, but it doesn't provide great data. This PR adds a generic analytics event function to add more event data when needed.

## Changes
1. Added `analyticsEventHandler`
2. Added `analyticsEventHandler_spec.test.js` for tests
3. Added `analyticsEventHandler` to the `LessonButton` implementation
4. Added tests for the new `LessonButton` analytics call. 