### PR TITLE
Improve Quiz and Lesson components, fix tracking issue

### DIFF
--- a/content/lessons/data-types/objects.md
+++ b/content/lessons/data-types/objects.md
@@ -30,4 +30,50 @@ readingLinks:
     description: "We will be dealing with objects and their properties throughout the session.
     A quick read-through of preventing mutations in object."
     title: "Preventing Object Mutation"
+preReadQuiz:
+  questions: 
+    - choices:
+      - value: It's a compound value by default, composed of other primitives.
+      - value: It's an immutable value by default, which cannot be modified.
+      - value: It's a mutable value by default, which can be modified.
+      correctChoices: 
+      - 2
+      description: Objects in JavaScript are "non-primitive" values. What does that mean?
+      explanation: The term 'compound' value does not apply to JavaScript. Objects are not immutable by default, and can be modified.
+      type: radio
+    - choices:
+      - value: erase object.foo;
+      - value: omit object['foo'];
+      - value: delete object.foo;
+      - value: remove 'foo' from object;
+      correctChoices: 
+      - 2
+      description: How can you delete a property from an object?
+      explanation: The 'erase', 'omit', and 'remove' operators do not exist in JavaScript
+      type: radio
+    - choices:
+      - value: new RegExp('ab+c')
+      - value: '[1, 2, 3, 4, 5]'
+      - value: Symbol('im an ES6 symbol')
+      - value: '42'
+      - value: '`Hello ${name}!`'
+      - value: '{ x: 0, y: 0, z: -1 }'
+      - value: function add(a, b) { return a + b; }
+      correctChoices: 
+      - 0
+      - 1
+      - 5
+      - 6
+      description: Select all valid Objects from the list of expressions below.
+      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
+      type: checkbox
+    - choices:
+      - value: The reference points to the value's location in memory; the variable doesn't contain the value.
+      - value: The reference is a copy of the original; the variable holds a copy of the value.
+      - value: The reference is an abstract inlined cached representation of the original non-primitive.
+      correctChoices: 
+      - 0
+      description: In JavaScript, a non-primitive value is one which can be mutated or modified. When a non-primitive value is assigned to a variable, it is said to be a "reference" to the value. What does a "reference" mean?
+      explanation: The first choice is the best answer;
+      type: radio   
 ---

--- a/content/lessons/data-types/types-and-equality.md
+++ b/content/lessons/data-types/types-and-equality.md
@@ -45,4 +45,52 @@ readingLinks:
   - link: "https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#implicit-coercion"
     description: One section from an excellent chapter in You Don't Know JS. This section describes the mechanisms behind implicit coercion. 
     title: Implicit coercion by YDKJS
+preReadQuiz:
+  description: Take this quiz to test your understanding of JavaScript Types and Equality!
+  questions: 
+    - choices:
+      - value: typeof
+      - value: gettype
+      - value: is
+      - value: instanceof
+      correctChoices: 
+      - 0
+      description: What operator should you use to find the type of a value in JavaScript
+      explanation: The 'typeof' operator is used to determine the type of a variable. 'gettype' and 'is' are not valid operators, and 'instanceof' tests whether a provided object has the same prototype constructor as a provided argument. 
+      type: radio
+    - choices:
+      - value: '7'
+      - value: '4'
+      - value: '6'
+      - value: '5'
+      - value: '3'
+      correctChoices: 
+      - 2
+      description: How many built-in types are defined by JavaScript?
+      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
+      type: radio
+    - choices:
+      - value: string
+      - value: 'null'
+      - value: undefined
+      - value: closure
+      - value: object
+      - value: function
+      - value: Error
+      correctChoices: 
+      - 0
+      - 1
+      - 2
+      - 4
+      description: Select all valid built-in types from the list below. (This isn't the full list.)
+      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
+      type: checkbox
+    - choices:
+      - value: 'True'
+      - value: 'False'
+      correctChoices: 
+      - 0
+      description: True or false? In JavaScript, _variables_ do not have types, only _values_ have types.
+      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
+      type: radio   
 ---

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -142,7 +142,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-google-gtag",
       options: {
-        trackingId: [siteConfig.googleAnalyticsId],
+        trackingIds: [siteConfig.googleAnalyticsId],
         pluginConfig: {
           head: true
         }

--- a/gatsby/create-pages.js
+++ b/gatsby/create-pages.js
@@ -79,11 +79,11 @@ const createPages = async ({ graphql, actions }) => {
         context: { slug: edge.node.fields.slug }
       });
       // Create quiz pages for every lesson
-      // createPage({
-      //   path: `${edge.node.fields.slug}/quiz`,
-      //   component: path.resolve("./src/templates/quiz-template.js"),
-      //   context: { slug: edge.node.fields.slug }
-      // });
+      createPage({
+        path: `${edge.node.fields.slug}/quiz`,
+        component: path.resolve("./src/templates/quiz-template.js"),
+        context: { slug: edge.node.fields.slug }
+      });
     }
   });
 

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -3,7 +3,7 @@ import StyledLink from "../Link";
 import Block from "../Block";
 import LessonButton from "../LessonButton";
 import ContentSection from "../ContentSection";
-import "./Lesson.scss";
+import "./lesson.scss";
 
 const Lesson = ({ lesson, slug }) => {
   const {
@@ -13,6 +13,7 @@ const Lesson = ({ lesson, slug }) => {
     videoLinks,
     readingLinks,
     preReadQuizLink,
+    preReadQuiz,
     course
   } = lesson.frontmatter;
   const path = slug.toLowerCase().split("/courses/")[1];
@@ -53,7 +54,8 @@ const Lesson = ({ lesson, slug }) => {
               allow="autoplay; encrypted-media"
               allowFullScreen
             />
-          ))}
+          ))
+        }
       </ContentSection>
 
       <ContentSection title=" " subTitle="Pre-read Materials">
@@ -85,13 +87,19 @@ const Lesson = ({ lesson, slug }) => {
           pre-read material. These quizzes are a great way to check your
           comprehension, and we highly recommend taking them.
         </Block>
-        <StyledLink isExternal variation={"tertiary"} path={preReadQuizLink}>
+        <StyledLink
+          path={preReadQuiz !== null ? `${slug}/quiz` : preReadQuizLink}
+          isExternal={preReadQuiz === null}
+          variation={"tertiary"}
+        >
           Quiz Link
         </StyledLink>
       </ContentSection>
 
       <ContentSection title=" " subTitle="Exercises">
-        <Block is="p" mb="16px">Click this exercise link will bring you directly to an online IDE called codesandbox.io.</Block>
+        <Block is="p" mb="16px">
+          Click this exercise link will bring you directly to an online IDE called codesandbox.io.
+        </Block>
         <LessonButton path={path} />
       </ContentSection>
 
@@ -106,7 +114,7 @@ const Lesson = ({ lesson, slug }) => {
           path="https://docs.google.com/forms/d/e/1FAIpQLSeiB_M1YmwwwG9BNhGnd1Nn_BhnzOfHFUDrZGz1PAvm8A1NxA/viewform"
           variation={"tertiary"}
         >
-            Survey Link
+          Survey Link
         </StyledLink>
       </ContentSection>
     </div>

--- a/src/components/Quiz/Question/question.scss
+++ b/src/components/Quiz/Question/question.scss
@@ -2,7 +2,7 @@
 @import '../../../assets/scss/variables';
 
 .Question {
-  margin-top: $spacing--medium;
+  margin-top: $spacing--large;
 
   &-choiceInput {
     margin: 0.4rem;
@@ -11,6 +11,9 @@
     &--isBold {
       font-weight: bold;
     }
+  }
+  &-explanation {
+    margin-bottom: $spacing--medium;
   }
   &-legend {
     background-color: $color--primary;

--- a/src/components/Quiz/Quiz.js
+++ b/src/components/Quiz/Quiz.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { Link } from "gatsby";
 import { formatQuestionId, getChoiceIndex, getQuestionIndex } from './quizUtilities';
+import ContentSection from "../ContentSection";
 import Question from "./Question";
 import questionValidator from './Question/questionValidator';
+import StyledLink from '../Link';
 import "./quiz.scss";
 
 const Quiz = ({ quiz, slug, title }) => {
@@ -58,6 +59,8 @@ const Quiz = ({ quiz, slug, title }) => {
 
   // Handles the submission of the quiz
   const handleQuizSubmit = () => {
+    // Scroll to the top of the page
+    window.scrollTo(0, 0);
     // Validate every question and update the state of the quiz
     const validatedQuestions = questions.map(questionValidator);
     updateQuizState({
@@ -68,37 +71,38 @@ const Quiz = ({ quiz, slug, title }) => {
 
   return (
     <div className="Quiz">
-      <Link className="Quiz-homeButton" to={slug}>
-        Back to lesson
-      </Link>
-      <h2 className="Quiz-title">{title} - Pre-Read Quiz</h2>
-      <div className="Quiz-body">
-        {quiz.description}
+      <div className="Quiz-homeButton">
+        <StyledLink variation={"tertiary"} path={slug}>
+          Back to lesson
+        </StyledLink>
       </div>
-      {/* Iterate over all questions in this Quiz */}
-      {
-        questions.map((question, questionIndex) => {
-          const questionId = formatQuestionId(questionIndex);
-          const questionTitle = `Q${questionIndex + 1}: ${question.description}`;
-          return (
-            <Question
-              handleInputChange={handleInputChange}
-              key={questionId}
-              question={question}
-              questionId={questionId}
-              questionIndex={questionIndex}
-              shouldShowCorrectChoice={shouldShowCorrectChoice}
-              title={questionTitle}
-            />
-          );
-        })
-      }
-      <button
-        className="Quiz-submitButton"
-        onClick={handleQuizSubmit}
-      >
-        Submit Quiz
-      </button>
+      <ContentSection subTitle={'Pre-Read Quiz'} title={title}>
+        {quiz.description && <p>{quiz.description}</p>}
+        {/* Iterate over all questions in this Quiz */}
+        {
+          questions.map((question, questionIndex) => {
+            const questionId = formatQuestionId(questionIndex);
+            const questionTitle = `Q${questionIndex + 1}: ${question.description}`;
+            return (
+              <Question
+                handleInputChange={handleInputChange}
+                key={questionId}
+                question={question}
+                questionId={questionId}
+                questionIndex={questionIndex}
+                shouldShowCorrectChoice={shouldShowCorrectChoice}
+                title={questionTitle}
+              />
+            );
+          })
+        }
+        <button
+          className="Quiz-submitButton"
+          onClick={handleQuizSubmit}
+        >
+          Submit Quiz
+        </button>
+      </ContentSection>
     </div>
   );
 };

--- a/src/components/Quiz/quiz.scss
+++ b/src/components/Quiz/quiz.scss
@@ -7,6 +7,10 @@
   margin: auto;
   max-width: $layout-width;
 
+  &-homeButton {
+    @include margin(1, 1.3, 0, 1.3);
+  }
+
   &-submitButton {
     border: 1px solid $color--border;
     border-radius: $button-border-radius;

--- a/src/templates/lesson-template.js
+++ b/src/templates/lesson-template.js
@@ -58,6 +58,14 @@ export const query = graphql`
           description
           title
         }
+        preReadQuiz {
+          description
+          questions {
+            choices {
+              value
+            }
+          }
+        }
       }
     }
   }

--- a/src/templates/quiz-template.js
+++ b/src/templates/quiz-template.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { graphql } from "gatsby";
 import Layout from "../components/Layout";
-import Quiz from "../components/Quiz";
 import Page from '../components/Page';
+import Quiz from "../components/Quiz";
 
 const QuizTemplate = ({ data }) => {
   const { title: siteTitle, subtitle: siteSubtitle } = data.site.siteMetadata;
@@ -29,12 +29,7 @@ const QuizTemplate = ({ data }) => {
           preReadQuiz === null ? (
             <h1>A quiz for this lesson is not ready yet!</h1>
           ) : (
-            <Layout
-              title={`${quizTitle} - ${siteTitle}`}
-              description={metaDescription}
-            >
-              <Quiz quiz={preReadQuiz} slug={slug} title={title} />
-            </Layout>
+            <Quiz quiz={preReadQuiz} slug={slug} title={title} />
           )
         }
       </Page>
@@ -42,46 +37,39 @@ const QuizTemplate = ({ data }) => {
   );
 };
 
-// export const query = graphql`
-//   query QuizBySlug($slug: String!) {
-//     site {
-//       siteMetadata {
-//         author {
-//           name
-//           contacts {
-//             twitter
-//           }
-//         }
-//         disqusShortname
-//         subtitle
-//         title
-//         url
-//       }
-//     }
-//     markdownRemark(fields: { slug: { eq: $slug } }) {
-//       id
-//       html
-//       fields {
-//         slug
-//         tagSlugs
-//       }
-//       frontmatter {
-//         title
-//         preReadQuiz {
-//           description
-//           questions {
-//             correctChoices
-//             description
-//             explanation
-//             type
-//             choices {
-//               value
-//             }
-//           }
-//         }
-//       }
-//     }
-//   }
-// `;
+export const query = graphql`
+  query QuizBySlug($slug: String!) {
+    site {
+      siteMetadata {
+        subtitle
+        title
+        url
+      }
+    }
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      id
+      html
+      fields {
+        slug
+        tagSlugs
+      }
+      frontmatter {
+        title
+        preReadQuiz {
+          description
+          questions {
+            correctChoices
+            description
+            explanation
+            type
+            choices {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export default QuizTemplate;


### PR DESCRIPTION
The Quiz and Lesson components needed some attention to get them up to speed as we prepare to move all of the Google Forms lessons to the in-house Quiz component. This MR does the work necessary to show our built-in quizzes if it exists, or shows the old Google Forms if it's not ready yet.

The two Data Types sessions were converted to use the new Quiz format, so we can test it out.

The Quiz component had some weird styling (it was mounting `<Layout>` and `<Page>` twice), so now it doesn't do that!

There was an issue with our Google Analytics tracking, with a bad prop name. This MR fixes that issue, so that `npm run build` can successfully execute (until now it couldn't.)