### PR TITLE
Adding new Travis options, updating Readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,15 @@ before_script:
   - "npm i -g gatsby"
   - "npm i"
 script:
-  - "npm run test"  
+  - "npm run test"
+before_deploy:
+  - npm run build
 deploy:
-  provider: script
-  script: npm run deploy
+  provider: pages
+  local_dir: public
   skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  keep_history: true
   on:
     branch: master
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Awesome Learning
+[![Build Status](https://travis-ci.org/wayfair/awesome-learning.svg?branch=master)](https://travis-ci.org/wayfair/awesome-learning)
+
+Learn JavaScript and Front-End Fundamentals at your own pace.
+
+[https://wayfair.github.io/awesome-learning/](https://wayfair.github.io/awesome-learning/)
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "An open source platform for learning front-end tech",
   "main": "n/a",
   "scripts": {
-    "develop": "yarn run clean && gatsby develop",
-    "build": "yarn run clean && gatsby build --prefix-paths",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public",
+    "develop": "npm run clean && gatsby develop",
+    "build": "npm run clean && gatsby build --prefix-paths",
+    "deploy": "npm run build && gh-pages -d public",
     "clean": "rimraf .cache public",
     "lint:js": "eslint --cache --ext .js,.jsx --ignore-pattern public .",
     "lint:scss": "stylelint \"src/**/*.scss\"",
-    "lint": "concurrently \"yarn run lint:js\" \"yarn run lint:scss\"",
+    "lint": "concurrently \"npm run lint:js\" \"npm run lint:scss\"",
     "test": "jest --config ./tests/jest-config.js",
     "test-coverage": "jest --coverage --config ./tests/jest-config.js",
     "test-watch": "jest --watch --config ./tests/jest-config.js"


### PR DESCRIPTION
I broke out the "build" step into a "before_deploy" step. That way, we can use the Travis GitHub provider to actually create the deploy, rather than trying to do that within NPM.