### PR TITLE
Fixing language and questions in Data Types quiz

### DIFF
--- a/content/lessons/data-types/types-and-equality.md
+++ b/content/lessons/data-types/types-and-equality.md
@@ -48,49 +48,33 @@ readingLinks:
 preReadQuiz:
   description: Take this quiz to test your understanding of JavaScript Types and Equality!
   questions: 
-    - choices:
+    - description: What operator should you use to find the type of a value in JavaScript?
+      choices:
       - value: typeof
       - value: gettype
       - value: is
       - value: instanceof
       correctChoices: 
       - 0
-      description: What operator should you use to find the type of a value in JavaScript
       explanation: The 'typeof' operator is used to determine the type of a variable. 'gettype' and 'is' are not valid operators, and 'instanceof' tests whether a provided object has the same prototype constructor as a provided argument. 
       type: radio
-    - choices:
+    - description: As of ES2015, how many built-in types are defined by JavaScript?
+      choices:
       - value: '7'
       - value: '4'
       - value: '6'
       - value: '5'
       - value: '3'
       correctChoices: 
-      - 2
-      description: How many built-in types are defined by JavaScript?
-      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
-      type: radio
-    - choices:
-      - value: string
-      - value: 'null'
-      - value: undefined
-      - value: closure
-      - value: object
-      - value: function
-      - value: Error
-      correctChoices: 
       - 0
-      - 1
-      - 2
-      - 4
-      description: Select all valid built-in types from the list below. (This isn't the full list.)
-      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
-      type: checkbox
-    - choices:
+      explanation: As of ES2015, the seven types are 'number', 'boolean', 'string', 'null', 'object', 'undefined', and 'Symbol'.
+      type: radio
+    - description: True or false? In JavaScript, _variables_ do not have types, only _values_ have types.
+      choices:
       - value: 'True'
       - value: 'False'
       correctChoices: 
       - 0
-      description: True or false? In JavaScript, _variables_ do not have types, only _values_ have types.
-      explanation: The seven types are 'number', 'boolean', 'string', 'function', 'object', 'Symbol', and 'undefined'.
+      explanation: In JavaScript, values have types, but variables (which refer to values) do not.
       type: radio   
 ---


### PR DESCRIPTION
Following a conversation with other engineers, we discovered some bugs in the Data Types quiz, especially with the wording on how many types there are in JavaScript. This MR fixes the question (and removes a redundant one) to make things easier to understand.