### PR TITLE
defaultTab option on lessons

### DIFF
--- a/content/lessons/array-methods/advanced-reduce.md
+++ b/content/lessons/array-methods/advanced-reduce.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Array-Methods/advanced-reduce
 course: Array-Methods
+defaultTab: tests
 tags:
   - Refactoring
 description: By now you've seen the power of `reduce`. This session will take it one step further and test your abilities to handle complex data manipulation. By the end of this session, you will feel confident working with `reduce`, and might even start seeing where you can use it in place of our other array methods.

--- a/content/lessons/array-methods/forEach.md
+++ b/content/lessons/array-methods/forEach.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Array-Methods/forEach
 course: Array-Methods
+defaultTab: tests
 tags:
   - Refactoring
 description: In this lesson you will be introduced to the most basic array method which iterates over an entire list - `forEach`. By the end of the lesson, you should be comfortable with thinking about writing methods which operate on an entire list of items, one item at a time.

--- a/content/lessons/array-methods/map-and-filter.md
+++ b/content/lessons/array-methods/map-and-filter.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Array-Methods/map-and-filter
 course: Array-Methods
+defaultTab: tests
 tags:
   - Refactoring
 description: filter creates a new array with elements that fall under a given criteria from an existing array. `map` creates a new array with the results of calling a provided function on every element in the calling array. By the end of this session, you will know how to write functional array iterations using `map` and `filter` that will allow you to create new, curated arrays.

--- a/content/lessons/array-methods/reduce.md
+++ b/content/lessons/array-methods/reduce.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Array-Methods/reduce
 course: Array-Methods
+defaultTab: tests
 tags:
   - Refactoring
 description: reduce is arguably the most versatile of Javascript's array prototype methods. `reduce` gives you the power to create a new data structure by iterating over an array and applying a callback of your creation. By the end of this session, you will understand the basics of `reduce`, and feel confident using it to simplify your data.

--- a/content/lessons/array-methods/sort.md
+++ b/content/lessons/array-methods/sort.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Array-Methods/sort
 course: Array-Methods
+defaultTab: tests
 tags:
   - Array Methods
   - Functional Programming

--- a/content/lessons/data-types/objects.md
+++ b/content/lessons/data-types/objects.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Data-Types/objects
 course: Data-Types
+defaultTab: tests
 tags:
   - Pass by Reference
   - Pass by caller

--- a/content/lessons/data-types/types-and-equality.md
+++ b/content/lessons/data-types/types-and-equality.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Data-Types/types-and-equality
 course: Data-Types
+defaultTab: tests
 tags:
   - Types
   - Coercion

--- a/content/lessons/functions-and-scope/closures.md
+++ b/content/lessons/functions-and-scope/closures.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Functions-and-Scope/closures
 course: Functions-and-Scope
+defaultTab: tests
 tags:
   - Closure
 description: "Closures are a powerful tool in _any_ language. In this session let's spend the

--- a/content/lessons/functions-and-scope/context-and-arrows.md
+++ b/content/lessons/functions-and-scope/context-and-arrows.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Functions-and-Scope/context-and-arrows
 course: Functions-and-Scope
+defaultTab: tests
 tags:
   - A Tag
 description: "

--- a/content/lessons/functions-and-scope/scope.md
+++ b/content/lessons/functions-and-scope/scope.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Functions-and-Scope/scope
 course: Functions-and-Scope
+defaultTab: tests
 tags:
   - Scope
   - JS Fundamentals

--- a/content/lessons/hooks/intro-to-react-hooks.md
+++ b/content/lessons/hooks/intro-to-react-hooks.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/React-Hooks/intro-to-react-hooks
 course: React-Hooks
+defaultTab: browser
 tags:
   - React
 description: |

--- a/content/lessons/promises/advanced-promises.md
+++ b/content/lessons/promises/advanced-promises.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Promises/advanced-promises
 course: Promises
+defaultTab: tests
 tags:
   - Async JS
   - Promises

--- a/content/lessons/promises/intro-to-promises.md
+++ b/content/lessons/promises/intro-to-promises.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Promises/intro-to-promises
 course: Promises
+defaultTab: tests
 tags:
   - Async JS
   - Promises

--- a/content/lessons/testing/component-testing.md
+++ b/content/lessons/testing/component-testing.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Testing/component-testing
 course: Testing
+defaultTab: tests
 tags:
   - Jest
   - Enzyme

--- a/content/lessons/testing/intro-to-unit-testing.md
+++ b/content/lessons/testing/intro-to-unit-testing.md
@@ -4,6 +4,7 @@ template: lesson
 draft: false
 slug: /courses/Testing/intro-to-unit-testing
 course: Testing
+defaultTab: tests
 tags:
   - Jest
 description: "Why do we need automated tests? Here's one good reason: You're going to test your changes anyway, why not automate it? In other words: you're going to

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -14,7 +14,8 @@ const Lesson = ({ lesson, slug }) => {
     readingLinks,
     preReadQuizLink,
     preReadQuiz,
-    course
+    course,
+    defaultTab
   } = lesson.frontmatter;
   // Split the description into different paragraphs based on new lines
   const descriptionParagraphs = description.split(/\r?\n\n/);
@@ -105,7 +106,7 @@ const Lesson = ({ lesson, slug }) => {
         <Block is="p" mb="16px">
           Click this exercise link will bring you directly to an online IDE called codesandbox.io.
         </Block>
-        <LessonButton path={path} />
+        <LessonButton defaultTab={defaultTab} path={path} />
       </ContentSection>
 
       <ContentSection title=" " subTitle="Session Feedback">

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -13,9 +13,11 @@ const handleEventClick = (path) => {
   }
 };
 
-export const PureLessonButton = ({ path, data, onClick }) => {
+export const PureLessonButton = ({
+  defaultTab, path, data, onClick
+}) => {
   const { repoOwner } = data.site.siteMetadata;
-  const fullPath = `https://codesandbox.io/s/github/${repoOwner}/awesome-learning-exercises/tree/master/${path}?fontsize=14&previewwindow=tests`;
+  const fullPath = `https://codesandbox.io/s/github/${repoOwner}/awesome-learning-exercises/tree/master/${path}?fontsize=14&previewwindow=${defaultTab}`;
   return (
     <OutboundLink
       className="LessonButton-link"

--- a/src/components/LessonButton/LessonButton.test.js
+++ b/src/components/LessonButton/LessonButton.test.js
@@ -13,10 +13,11 @@ describe("LessonButton", () => {
           repoOwner: "wayfair"
         }
       }
-    }
+    },
+    defaultTab: 'tests'
   };
 
-  it("creates a link with the right codesandox url", () => {
+  it("creates a link with the right codesandbox url", () => {
     const wrapper = mount(<PureLessonButton {...props} />);
     expect(wrapper.find("a").props().href).toBe(
       "https://codesandbox.io/s/github/wayfair/awesome-learning-exercises/tree/master/data-types/objects?fontsize=14&previewwindow=tests"

--- a/src/templates/lesson-template.js
+++ b/src/templates/lesson-template.js
@@ -53,6 +53,7 @@ export const query = graphql`
         timeToCompletion
         videoLinks
         preReadQuizLink
+        defaultTab
         readingLinks {
           link
           description


### PR DESCRIPTION
This MR introduces the "defaultTab" prop for lessons. We normally want to start on the tests CodeSandbox tab for almost all lessons. For React Hooks (and future courses), we want to start on the Browser tab. This MR introduces that as an option, and passes the right options to `LessonButton`!