### PR TITLE
Reduce need to import SCSS variables/mixins in every file

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -90,7 +90,8 @@ module.exports = {
       options: {
         cssLoaderOptions: {
           camelCase: false
-        }
+        },
+        data: `@import "${__dirname}/src/assets/scss/styles";`,
       }
     }
   ]

--- a/src/components/ContentSection/ContentSection.scss
+++ b/src/components/ContentSection/ContentSection.scss
@@ -1,11 +1,8 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .ContentSection {
   $baseSelector: &;
   @include padding(2, 0, 2, 0);
   @include margin(0, 1.3, 0, 1.3);
-  
+
   display: grid;
   grid-gap: $spacing--medium;
   @include breakpoint-md {
@@ -15,11 +12,11 @@
     &--alignLeft {
       text-align: left;
     }
-  
+
     &--alignCenter {
       text-align: center;
     }
-  
+
     &--textLight h1 {
       font-weight: 500;
       color: $color--light;
@@ -34,7 +31,7 @@
     &--alignLeft {
       text-align: left;
     }
-      &--alignCenter {
+    &--alignCenter {
       text-align: center;
     }
   }

--- a/src/components/Course/Course.scss
+++ b/src/components/Course/Course.scss
@@ -1,12 +1,9 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Course {
   &-backLink {
     @include margin(1, 1.3, 0, 1.3);
   }
   &-footer {
     border-top: 1px solid $color--border;
-    @include margin(2, 1.3 ,0 ,1.3 )
+    @include margin(2, 1.3, 0, 1.3);
   }
 }

--- a/src/components/Courses/Courses.scss
+++ b/src/components/Courses/Courses.scss
@@ -1,16 +1,13 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .CourseList {
   $rootSelector: &;
   &-item {
     @include margin-bottom(1.25);
     &:last-child {
-      @include margin-bottom(.5);
+      @include margin-bottom(0.5);
     }
   }
 
-  &-card { 
+  &-card {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -23,12 +20,12 @@
   }
 
   &-itemTitle {
-    @include margin-bottom(.5);
+    @include margin-bottom(0.5);
   }
 
   &-itemDescription {
     @include line-height(1);
-    @include margin-bottom(.75);
+    @include margin-bottom(0.75);
   }
 
   &--isHorizontal {

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,5 +1,3 @@
-@import '../../assets/scss/variables';
-
 .Header {
   position: sticky;
   top: 0;

--- a/src/components/Landing/Landing.scss
+++ b/src/components/Landing/Landing.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Landing {
   $baseSelector: &;
 

--- a/src/components/Landing/trackCard.scss
+++ b/src/components/Landing/trackCard.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .TrackCard {
   display: flex;
   flex-direction: column;
@@ -33,4 +30,3 @@
     fill: $color--secondary;
   }
 }
-

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -1,11 +1,8 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Layout {
   max-width: $layout-width;
   padding: 0 1.5rem;
   margin: 0 auto;
-  &--fullBleed { 
+  &--fullBleed {
     padding: 0;
     max-width: 100%;
   }

--- a/src/components/Lesson/lesson.scss
+++ b/src/components/Lesson/lesson.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Lesson {
   padding: 0 15px;
   margin: 0 auto;
@@ -32,13 +29,13 @@
           font-size: $font--large;
           margin-top: 0;
           @include margin-bottom(1);
-          @include line-height(1.5)
+          @include line-height(1.5);
         }
       }
     }
 
     & a {
-      text-decoration: underline
+      text-decoration: underline;
     }
 
     & img {
@@ -50,4 +47,3 @@
     font-weight: $font-weight--bold;
   }
 }
-

--- a/src/components/LessonButton/LessonButton.scss
+++ b/src/components/LessonButton/LessonButton.scss
@@ -1,5 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
 .LessonButton {
   &-link {
     text-decoration: none;

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Link {
   text-decoration: none;
   &--primary {
@@ -19,7 +16,7 @@
     @include breakpoint-md {
       font-size: $font--large;
       @include line-height(1.125);
-      @include margin-bottom(1.125)
+      @include margin-bottom(1.125);
     }
   }
 

--- a/src/components/Page/Page.scss
+++ b/src/components/Page/Page.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Page {
   @include margin-bottom(2);
 
@@ -9,11 +6,11 @@
     @include breakpoint-sm {
       padding: 30px 0;
     }
-    
+
     @include breakpoint-md {
       padding: 40px 0;
     }
-    
+
     @include breakpoint-lg {
       padding: 40px 35px;
     }
@@ -31,5 +28,4 @@
     @include line-height(1);
     @include margin(0, 0, 1);
   }
-
 }

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/variables';
-@import '../../assets/scss/mixins';
-
 .Pagination {
   @include margin-top(2);
   display: flex;
@@ -18,9 +15,7 @@
       &:focus {
         color: $color--primary;
       }
-
     }
-
   }
 
   &-next {
@@ -38,7 +33,5 @@
         color: $color--primary;
       }
     }
-
   }
-
 }

--- a/src/components/Quiz/quiz.scss
+++ b/src/components/Quiz/quiz.scss
@@ -1,6 +1,3 @@
-@import '../../assets/scss/mixins';
-@import '../../assets/scss/variables';
-
 .Quiz {
   $rootSelector: &;
   display: block;

--- a/src/components/Text/Text.scss
+++ b/src/components/Text/Text.scss
@@ -1,5 +1,3 @@
-@import '../../assets/scss/variables';
-
 .Text {
   color: $color--base;
   &--large {


### PR DESCRIPTION
## Description
@SheaBelsky

 I just completed the issue.

- I added a configuration for gatsby sass to load the file containing the variables and mixins automatically. You can take a further look at the official gatsby documentation: [https://www.gatsbyjs.org/packages/gatsby-plugin-sass/#other-options](url)

- Also removed all the unnecessary references to variables and mixins from the component scss files.

## Related Issues
#61 


## Additional Notes
Thanks for letting me contribute to your awesome project and for helping me on getting a t-shit in the Hacktober Fest! 

Cheers!