### PR TITLE
fix: added missing PropTypes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,13 @@
 {
   "parser": "babel-eslint",
-  "extends": [
-    "airbnb-base",
-    "prettier"
-  ],
+  "extends": ["airbnb-base", "prettier"],
   "env": {
     "browser": true,
     "node": true,
     "es6": true,
     "jest/globals": true
   },
-  "plugins": [
-    "react",
-    "jest",
-    "jsx-a11y",
-    "import"
-  ],
+  "plugins": ["react", "jest", "jsx-a11y", "import"],
   "globals": {
     "graphql": true
   },
@@ -23,10 +15,7 @@
     "comma-dangle": 0,
     "import/imports-first": 0,
     "global-require": 2,
-    "arrow-body-style": [
-      2,
-      "as-needed"
-    ],
+    "arrow-body-style": [2, "as-needed"],
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -37,7 +26,8 @@
     "implicit-arrow-linebreak": 0,
     "dot-notation": 0,
     "no-console": [
-      "error", {
+      "error",
+      {
         "allow": ["error"]
       }
     ],
@@ -52,8 +42,14 @@
     "react/jsx-no-undef": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,
-    "indent": ["error", 2, {
-      "SwitchCase": 1
-    }]
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "react/no-unused-prop-types": 1,
+    "react/prop-types": 1
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 .gatsby-context.js
 .idea
 gatsby-starter-lumen.iml
+yarn.lock
+eslintresults.json

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:scss": "stylelint 'src/**/*.scss'",
     "test": "jest --config ./tests/jest-config.js",
     "test-coverage": "jest --coverage --config ./tests/jest-config.js",
-    "test-watch": "jest --watch --config ./tests/jest-config.js"
+    "test-watch": "jest --watch --config ./tests/jest-config.js",
+    "eslint-report": "./node_modules/.bin/eslint ./src -f json -o eslintresults.json"
   },
   "repository": "https://github.com/wayfair/awesome-learning",
   "author": "Awesome Learning™ <awesomelearning@wayfair.com>",
@@ -34,6 +35,7 @@
     "node": "^8 || ^10"
   },
   "dependencies": {
+    "@stanfaas/proptypes": "^1.3.0",
     "classnames": "^2.2.6",
     "codecov": "^3.6.1",
     "gatsby": "^2.15.28",

--- a/src/components/Block/Block.js
+++ b/src/components/Block/Block.js
@@ -25,6 +25,11 @@ const Block = ({
 };
 
 Block.propTypes = {
+  children: PropTypes.string,
+  mt: PropTypes.string,
+  mb: PropTypes.string,
+  ml: PropTypes.string,
+  mr: PropTypes.string,
   is: PropTypes.string
 };
 

--- a/src/components/ContentSection/ContentSection.js
+++ b/src/components/ContentSection/ContentSection.js
@@ -36,6 +36,7 @@ const ContentSection = ({
 };
 
 ContentSection.propTypes = {
+  titleAlignment: PropTypes.string,
   className: PropTypes.string,
   title: PropTypes.string,
   subTitle: PropTypes.string,

--- a/src/components/Course/Content/Content.js
+++ b/src/components/Course/Content/Content.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './Content.scss';
 
 const Content = ({ body, title }) => (
@@ -8,4 +9,8 @@ const Content = ({ body, title }) => (
   </div>
 );
 
+Content.propTypes = {
+  body: PropTypes.string,
+  title: PropTypes.string,
+}
 export default Content;

--- a/src/components/Course/Course.js
+++ b/src/components/Course/Course.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import Tags from "./Tags";
 import StyledLink from "../Link";
 import CourseCard from "../CourseCard";
@@ -43,4 +44,7 @@ const Course = ({ course }) => {
   );
 };
 
+Course.propTypes = {
+  course: PropTypes.string,
+}
 export default Course;

--- a/src/components/Course/Tags/Tags.js
+++ b/src/components/Course/Tags/Tags.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import StyledLink from "../../Link";
 import './Tags.scss';
 
@@ -16,4 +17,8 @@ const Tags = ({ tags, tagSlugs }) => (
   </div>
 );
 
+Tags.propTypes = {
+  tags: PropTypes.string,
+  tagSlugs: PropTypes.string,
+}
 export default Tags;

--- a/src/components/Courses/Courses.js
+++ b/src/components/Courses/Courses.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import StyledLink from "../Link";
 import "./Courses.scss";
 
@@ -41,4 +42,8 @@ const Courses = ({ edges, isHorizontal }) =>
     </div>
   ));
 
+Courses.propTypes = {
+  edges: PropTypes.string,
+  isHorizontal: PropTypes.string,
+}
 export default Courses;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { Link, graphql, StaticQuery } from "gatsby";
 import Menu from "./Menu";
 import Icon from "../Icon";
@@ -63,4 +64,7 @@ export const Header = props => (
   />
 );
 
+Header.propTypes = {
+  data: PropTypes.string,
+}
 export default Header;

--- a/src/components/Header/Menu/Menu.js
+++ b/src/components/Header/Menu/Menu.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { Link } from "gatsby";
 import Icon from "../../Icon";
 import { getIcon } from "../../../utils";
@@ -17,4 +18,7 @@ const Menu = ({ menu }) => (
   </div>
 );
 
+Menu.propTypes = {
+  menu: PropTypes.string,
+}
 export default Menu;

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './Icon.scss';
 
 const Icon = ({ icon, cssClasses = "" }) => (
@@ -7,4 +8,8 @@ const Icon = ({ icon, cssClasses = "" }) => (
   </svg>
 );
 
+Icon.propTypes = {
+  icon: PropTypes.string,
+  cssClasses: PropTypes.string,
+}
 export default Icon;

--- a/src/components/Landing/trackCard.js
+++ b/src/components/Landing/trackCard.js
@@ -19,6 +19,7 @@ const TrackCard = props => (
 );
 
 TrackCard.propTypes = {
+  icon: PropTypes.string,
   title: PropTypes.string.isRequired,
   subTitle: PropTypes.string.isRequired,
   path: PropTypes.string

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import Helmet from "react-helmet";
 import cx from "classnames";
 import Header from "../Header";
@@ -30,4 +31,10 @@ Layout.defaultProps = {
   isFullBleed: false
 };
 
+Layout.propTypes = {
+  children: PropTypes.string,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  isFullBleed: PropTypes.string,
+}
 export default Layout;

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import StyledLink from '../Link';
 import Block from '../Block';
 import LessonButton, { PrimitiveLessonButton } from '../LessonButton';
@@ -137,4 +138,8 @@ const Lesson = ({ lesson, slug }) => {
   );
 };
 
+Lesson.propTypes = {
+  lesson: PropTypes.string,
+  slug: PropTypes.string,
+}
 export default Lesson;

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -57,6 +57,11 @@ const LessonButton = props => (
 );
 
 PureLessonButton.propTypes = {
+  path: PropTypes.string,
+  onClick: PropTypes.string,
+  children: PropTypes.string,
+  data: PropTypes.string,
+  defaultTab: PropTypes.string,
   path: PropTypes.string.isRequired,
   repoName: PropTypes.string,
   repoOwner: PropTypes.string.isRequired,

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -57,9 +57,6 @@ const LessonButton = props => (
 );
 
 PureLessonButton.propTypes = {
-  path: PropTypes.string,
-  onClick: PropTypes.string,
-  children: PropTypes.string,
   data: PropTypes.string,
   defaultTab: PropTypes.string,
   path: PropTypes.string.isRequired,

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -44,6 +44,8 @@ const StyledLink = ({
 };
 
 StyledLink.propTypes = {
+  children: PropTypes.string,
+  isBlock: PropTypes.string,
   variation: PropTypes.oneOf(LINK_VARIATIONS),
   path: PropTypes.string.isRequired,
   isButton: PropTypes.bool,

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './Page.scss';
 
 const Page = ({ title, children }) => (
@@ -12,4 +13,8 @@ const Page = ({ title, children }) => (
   </div>
 );
 
+Page.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.string,
+}
 export default Page;

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { Link } from "gatsby";
 import { PAGINATION } from "../../constants";
 import "./Pagination.scss";
@@ -27,4 +28,10 @@ const Pagination = ({
   </div>
 );
 
+Pagination.propTypes = {
+  prevPagePath: PropTypes.string,
+  nextPagePath: PropTypes.string,
+  hasNextPage: PropTypes.string,
+  hasPrevPage: PropTypes.string,
+}
 export default Pagination;

--- a/src/components/Quiz/Question/Question.js
+++ b/src/components/Quiz/Question/Question.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { formatChoiceId } from "../quizUtilities";
 import "./question.scss";
@@ -65,4 +66,12 @@ const Question = ({
   </fieldset>
 );
 
+Question.propTypes = {
+  handleInputChange: PropTypes.string,
+  question: PropTypes.string,
+  questionId: PropTypes.string,
+  questionIndex: PropTypes.string,
+  shouldShowCorrectChoice: PropTypes.string,
+  title: PropTypes.string,
+}
 export default Question;

--- a/src/components/Quiz/Quiz.js
+++ b/src/components/Quiz/Quiz.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import PropTypes from 'prop-types';
 import { formatQuestionId, getChoiceIndex, getQuestionIndex } from './quizUtilities';
 import ContentSection from "../ContentSection";
 import Question from "./Question";
@@ -107,4 +108,9 @@ const Quiz = ({ quiz, slug, title }) => {
   );
 };
 
+Quiz.propTypes = {
+  quiz: PropTypes.string,
+  slug: PropTypes.string,
+  title: PropTypes.string,
+}
 export default Quiz;

--- a/src/templates/course-list-template.js
+++ b/src/templates/course-list-template.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import { graphql } from 'gatsby';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
 import Layout from '../components/Layout';
 import Courses from '../components/Courses';
 import Page from '../components/Page';
 import Pagination from '../components/Pagination';
 
-const CourseListTemplate = ({ data, pageContext }) => {
-  const {
-    title: siteTitle,
-    subtitle: siteSubtitle
-  } = data.site.siteMetadata;
+const CourseListTemplate = ({data, pageContext}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
   const {
     currentPage,
@@ -19,8 +17,11 @@ const CourseListTemplate = ({ data, pageContext }) => {
     nextPagePath
   } = pageContext;
 
-  const { edges } = data.allMarkdownRemark;
-  const pageTitle = currentPage > 0 ? `Courses - Page ${currentPage} - ${siteTitle}` : siteTitle;
+  const {edges} = data.allMarkdownRemark;
+  const pageTitle =
+    currentPage > 0
+      ? `Courses - Page ${currentPage} - ${siteTitle}`
+      : siteTitle;
 
   return (
     <Layout title={pageTitle} description={siteSubtitle}>
@@ -46,13 +47,11 @@ export const query = graphql`
       }
     }
     allMarkdownRemark(
-        limit: $coursesLimit,
-        skip: $coursesOffset,
-        filter: { frontmatter: { template: { eq: "course" }, draft: { ne: true } } },
-        sort: {
-          fields: [frontmatter___title]
-          order: [ASC]
-        }){
+      limit: $coursesLimit
+      skip: $coursesOffset
+      filter: {frontmatter: {template: {eq: "course"}, draft: {ne: true}}}
+      sort: {fields: [frontmatter___title], order: [ASC]}
+    ) {
       edges {
         node {
           fields {
@@ -69,5 +68,10 @@ export const query = graphql`
     }
   }
 `;
+
+CourseListTemplate.propTypes = {
+  data: PropTypes.string,
+  pageContext: PropTypes.string
+};
 
 export default CourseListTemplate;

--- a/src/templates/course-template.js
+++ b/src/templates/course-template.js
@@ -1,24 +1,26 @@
 import React from 'react';
-import { graphql } from 'gatsby';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
 import Layout from '../components/Layout';
 import Course from '../components/Course';
 import Page from '../components/Page';
 
-const CourseTemplate = ({ data }) => {
-  const {
-    title: siteTitle,
-    subtitle: siteSubtitle
-  } = data.site.siteMetadata;
+const CourseTemplate = ({data}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
   const {
     title: courseTitle,
     description: courseDescription
   } = data.markdownRemark.frontmatter;
 
-  const metaDescription = courseDescription !== null ? courseDescription : siteSubtitle;
+  const metaDescription =
+    courseDescription !== null ? courseDescription : siteSubtitle;
 
   return (
-    <Layout title={`${courseTitle} - ${siteTitle}`} description={metaDescription}>
+    <Layout
+      title={`${courseTitle} - ${siteTitle}`}
+      description={metaDescription}
+    >
       <Page>
         <Course course={data.markdownRemark} />
       </Page>
@@ -35,7 +37,7 @@ export const query = graphql`
         url
       }
     }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+    markdownRemark(fields: {slug: {eq: $slug}}) {
       id
       html
       fields {
@@ -55,5 +57,9 @@ export const query = graphql`
     }
   }
 `;
+
+CourseTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default CourseTemplate;

--- a/src/templates/index-template.js
+++ b/src/templates/index-template.js
@@ -1,16 +1,13 @@
 import React from 'react';
-import { graphql } from 'gatsby';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
 import Layout from '../components/Layout';
 import Landing from '../components/Landing';
 
+const IndexTemplate = ({data}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
-const IndexTemplate = ({ data }) => {
-  const {
-    title: siteTitle,
-    subtitle: siteSubtitle
-  } = data.site.siteMetadata;
-
-  const { edges } = data.allMarkdownRemark;
+  const {edges} = data.allMarkdownRemark;
 
   return (
     <Layout title={siteTitle} description={siteSubtitle} isFullBleed>
@@ -28,10 +25,10 @@ export const query = graphql`
       }
     }
     allMarkdownRemark(
-        limit: $coursesLimit,
-        skip: $coursesOffset,
-        filter: { frontmatter: { template: { eq: "course" }, draft: { ne: true } } },
-      ){
+      limit: $coursesLimit
+      skip: $coursesOffset
+      filter: {frontmatter: {template: {eq: "course"}, draft: {ne: true}}}
+    ) {
       edges {
         node {
           fields {
@@ -48,5 +45,9 @@ export const query = graphql`
     }
   }
 `;
+
+IndexTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default IndexTemplate;

--- a/src/templates/lesson-template.js
+++ b/src/templates/lesson-template.js
@@ -1,20 +1,22 @@
-import React from "react";
-import { graphql } from "gatsby";
-import Layout from "../components/Layout";
-import Lesson from "../components/Lesson";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
+import Layout from '../components/Layout';
+import Lesson from '../components/Lesson';
 import Page from '../components/Page';
 
-const LessonTemplate = ({ data }) => {
-  const { title: siteTitle, subtitle: siteSubtitle } = data.site.siteMetadata;
+const LessonTemplate = ({data}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
   const {
     title: lessonTitle,
     description: courseDescription
   } = data.markdownRemark.frontmatter;
 
-  const { slug } = data.markdownRemark.fields;
+  const {slug} = data.markdownRemark.fields;
 
-  const metaDescription = courseDescription !== null ? courseDescription : siteSubtitle;
+  const metaDescription =
+    courseDescription !== null ? courseDescription : siteSubtitle;
 
   return (
     <Layout
@@ -37,7 +39,7 @@ export const query = graphql`
         url
       }
     }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+    markdownRemark(fields: {slug: {eq: $slug}}) {
       id
       html
       fields {
@@ -71,5 +73,9 @@ export const query = graphql`
     }
   }
 `;
+
+LessonTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default LessonTemplate;

--- a/src/templates/not-found-template.js
+++ b/src/templates/not-found-template.js
@@ -1,11 +1,12 @@
-import React from "react";
-import { Container, Row, Col } from "react-grid-system";
-import { graphql } from "gatsby";
-import Layout from "../components/Layout";
-import Page from "../components/Page";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Container, Row, Col} from 'react-grid-system';
+import {graphql} from 'gatsby';
+import Layout from '../components/Layout';
+import Page from '../components/Page';
 
-const NotFoundTemplate = ({ data }) => {
-  const { title, subtitle } = data.site.siteMetadata;
+const NotFoundTemplate = ({data}) => {
+  const {title, subtitle} = data.site.siteMetadata;
 
   return (
     <Layout title={`Not Found - ${title}`} description={subtitle}>
@@ -32,5 +33,9 @@ export const query = graphql`
     }
   }
 `;
+
+NotFoundTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default NotFoundTemplate;

--- a/src/templates/page-template.js
+++ b/src/templates/page-template.js
@@ -1,18 +1,19 @@
-import React from "react";
-import { graphql } from "gatsby";
-import { Container, Row, Col } from "react-grid-system";
-import Layout from "../components/Layout";
-import Page from "../components/Page";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
+import {Container, Row, Col} from 'react-grid-system';
+import Layout from '../components/Layout';
+import Page from '../components/Page';
 
-const PageTemplate = ({ data }) => {
-  const { title: siteTitle, subtitle: siteSubtitle } = data.site.siteMetadata;
+const PageTemplate = ({data}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
   const {
     title: pageTitle,
     description: pageDescription
   } = data.markdownRemark.frontmatter;
 
-  const { html: pageBody } = data.markdownRemark;
+  const {html: pageBody} = data.markdownRemark;
 
   const metaDescription =
     pageDescription !== null ? pageDescription : siteSubtitle;
@@ -23,7 +24,7 @@ const PageTemplate = ({ data }) => {
         <Row>
           <Col>
             <Page title={pageTitle}>
-              <div dangerouslySetInnerHTML={{ __html: pageBody }} />
+              <div dangerouslySetInnerHTML={{__html: pageBody}} />
             </Page>
           </Col>
         </Row>
@@ -40,7 +41,7 @@ export const query = graphql`
         subtitle
       }
     }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+    markdownRemark(fields: {slug: {eq: $slug}}) {
       id
       html
       frontmatter {
@@ -51,5 +52,9 @@ export const query = graphql`
     }
   }
 `;
+
+PageTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default PageTemplate;

--- a/src/templates/quiz-template.js
+++ b/src/templates/quiz-template.js
@@ -1,37 +1,38 @@
-import React from "react";
-import { graphql } from "gatsby";
-import Layout from "../components/Layout";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {graphql} from 'gatsby';
+import Layout from '../components/Layout';
 import Page from '../components/Page';
-import Quiz from "../components/Quiz";
+import Quiz from '../components/Quiz';
 
-const QuizTemplate = ({ data }) => {
-  const { title: siteTitle, subtitle: siteSubtitle } = data.site.siteMetadata;
+const QuizTemplate = ({data}) => {
+  const {title: siteTitle, subtitle: siteSubtitle} = data.site.siteMetadata;
 
   const {
     title: quizTitle,
     description: courseDescription
   } = data.markdownRemark.frontmatter;
 
-  const { slug } = data.markdownRemark.fields;
-  const { title } = data.markdownRemark.frontmatter;
+  const {slug} = data.markdownRemark.fields;
+  const {title} = data.markdownRemark.frontmatter;
 
-  const metaDescription = courseDescription !== null ? courseDescription : siteSubtitle;
+  const metaDescription =
+    courseDescription !== null ? courseDescription : siteSubtitle;
 
-  const { markdownRemark: { frontmatter: { preReadQuiz } } } = data;
+  const {
+    markdownRemark: {
+      frontmatter: {preReadQuiz}
+    }
+  } = data;
 
   return (
-    <Layout
-      title={`${quizTitle} - ${siteTitle}`}
-      description={metaDescription}
-    >
+    <Layout title={`${quizTitle} - ${siteTitle}`} description={metaDescription}>
       <Page>
-        {
-          preReadQuiz === null ? (
-            <h1>A quiz for this lesson is not ready yet!</h1>
-          ) : (
-            <Quiz quiz={preReadQuiz} slug={slug} title={title} />
-          )
-        }
+        {preReadQuiz === null ? (
+          <h1>A quiz for this lesson is not ready yet!</h1>
+        ) : (
+          <Quiz quiz={preReadQuiz} slug={slug} title={title} />
+        )}
       </Page>
     </Layout>
   );
@@ -46,7 +47,7 @@ export const query = graphql`
         url
       }
     }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+    markdownRemark(fields: {slug: {eq: $slug}}) {
       id
       html
       fields {
@@ -72,5 +73,9 @@ export const query = graphql`
     }
   }
 `;
+
+QuizTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default QuizTemplate;

--- a/src/templates/tag-template.js
+++ b/src/templates/tag-template.js
@@ -47,6 +47,7 @@ const TagTemplate = ({ data, pageContext }) => {
 };
 
 TagTemplate.propTypes = {
+  pageContext: PropTypes.string,
   data: PropTypes.shape({
     allMarkdownRemark: PropTypes.shape({
       edges: PropTypes.array.isRequired

--- a/src/templates/tags-list-template.js
+++ b/src/templates/tags-list-template.js
@@ -1,13 +1,14 @@
-import React from "react";
-import { Link, graphql } from "gatsby";
-import kebabCase from "lodash/kebabCase";
-import { Container, Row, Col } from "react-grid-system";
-import Layout from "../components/Layout";
-import Page from "../components/Page";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link, graphql} from 'gatsby';
+import kebabCase from 'lodash/kebabCase';
+import {Container, Row, Col} from 'react-grid-system';
+import Layout from '../components/Layout';
+import Page from '../components/Page';
 
-const TagsListTemplate = ({ data }) => {
-  const { title, subtitle } = data.site.siteMetadata;
-  const { group } = data.allMarkdownRemark;
+const TagsListTemplate = ({data}) => {
+  const {title, subtitle} = data.site.siteMetadata;
+  const {group} = data.allMarkdownRemark;
 
   return (
     <Layout title={`Tags - ${title}`} description={subtitle}>
@@ -41,9 +42,7 @@ export const query = graphql`
       }
     }
     allMarkdownRemark(
-      filter: {
-        frontmatter: { template: { eq: "course" }, draft: { ne: true } }
-      }
+      filter: {frontmatter: {template: {eq: "course"}, draft: {ne: true}}}
     ) {
       group(field: frontmatter___tags) {
         fieldValue
@@ -52,5 +51,9 @@ export const query = graphql`
     }
   }
 `;
+
+TagsListTemplate.propTypes = {
+  data: PropTypes.string
+};
 
 export default TagsListTemplate;


### PR DESCRIPTION
## Description

Automatically added missing PropTypes for all files. I've use a NodeJS module I wrote myself, you can find more info about it here: https://www.npmjs.com/package/@stanfaas/proptypes

There is an issue that comes out of this PR, you'll need to change the actual types manually when working on this project as my CLI tool will set every PropType to string, since the actual type is not known upfront.

###Before:
![image](https://user-images.githubusercontent.com/20415276/66251793-486ec980-e754-11e9-8798-e3ab760a3d61.png)

###After:
![image](https://user-images.githubusercontent.com/20415276/66251797-5886a900-e754-11e9-8fad-140924fcad6f.png)


## Related Issues

Fixes #9 
