### PR TITLE
feat: add useStorage hook for tracking the last lesson via localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .gatsby-context.js
 .idea
 gatsby-starter-lumen.iml
+yarn.lock

--- a/src/components/CourseCard/CourseCard.test.js
+++ b/src/components/CourseCard/CourseCard.test.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import CourseCard from './CourseCard';
+import LastLessonProvider from '../../providers/LastLessonProvider';
 
 const PROPS = {
   link: '/courses',
@@ -16,7 +17,11 @@ const PROPS = {
 
 describe('Course Card', () => {
   it('Renders a title, link, and description', () => {
-    const {getByText} = render(<CourseCard {...PROPS} />);
+    const {getByText} = render(
+      <LastLessonProvider>
+        <CourseCard {...PROPS} />
+      </LastLessonProvider>
+    );
     expect(getByText(PROPS.description)).toBeTruthy();
     expect(getByText(PROPS.title)).toBeTruthy();
     expect(getByText(`Learn ${PROPS.title}`).getAttribute('to')).toBe(

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,13 +1,14 @@
-import React from "react";
-import Helmet from "react-helmet";
-import cx from "classnames";
-import Header from "../Header";
+import React from 'react';
+import Helmet from 'react-helmet';
+import cx from 'classnames';
+import Header from '../Header';
 
-import "./Layout.scss";
+import './Layout.scss';
+import LastLessonProvider from '../../providers/LastLessonProvider';
 
-const Layout = ({ children, title, description, isFullBleed }) => {
-  const layoutClass = cx("Layout", {
-    "Layout--fullBleed": isFullBleed
+const Layout = ({children, title, description, isFullBleed}) => {
+  const layoutClass = cx('Layout', {
+    'Layout--fullBleed': isFullBleed
   });
   return (
     <>
@@ -21,7 +22,9 @@ const Layout = ({ children, title, description, isFullBleed }) => {
         />
       </Helmet>
       <Header />
-      <div className={layoutClass}>{children}</div>
+      <div className={layoutClass}>
+        <LastLessonProvider>{children}</LastLessonProvider>
+      </div>
     </>
   );
 };

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import StyledLink from '../Link';
 import Block from '../Block';
-import LessonButton, { PrimitiveLessonButton } from '../LessonButton';
+import LessonButton, {PrimitiveLessonButton} from '../LessonButton';
 import ContentSection from '../ContentSection';
 import './lesson.scss';
 
-const Lesson = ({ lesson, slug }) => {
+const Lesson = ({lesson, slug}) => {
   const {
     title,
     description,
@@ -18,6 +18,7 @@ const Lesson = ({ lesson, slug }) => {
     defaultTab,
     secondaryExerciseUrl
   } = lesson.frontmatter;
+
   // Split the description into different paragraphs based on new lines
   const descriptionParagraphs = description.split(/\r?\n\n/);
   const path = slug.toLowerCase().split('/courses/')[1];
@@ -51,8 +52,8 @@ const Lesson = ({ lesson, slug }) => {
           Check out this content before your session begins to get an idea of
           what you will be working on.
         </Block>
-        {videoLinks 
-          && videoLinks.map(link => (
+        {videoLinks &&
+          videoLinks.map(link => (
             <iframe
               key={link}
               width="100%"
@@ -103,6 +104,7 @@ const Lesson = ({ lesson, slug }) => {
             path={preReadQuiz !== null ? `${slug}/quiz` : preReadQuizLink}
             isExternal={preReadQuiz === null}
             variation={'tertiary'}
+            lessonData={lesson}
           >
             Quiz Link
           </StyledLink>
@@ -111,11 +113,18 @@ const Lesson = ({ lesson, slug }) => {
 
       <ContentSection title=" " subTitle="Exercises">
         {secondaryExerciseUrl ? (
-          <PrimitiveLessonButton path={secondaryExerciseUrl}>
+          <PrimitiveLessonButton
+            path={secondaryExerciseUrl}
+            lessonData={lesson}
+          >
             Start the Workshop
           </PrimitiveLessonButton>
         ) : (
-          <LessonButton defaultTab={defaultTab} path={path} />
+          <LessonButton
+            defaultTab={defaultTab}
+            path={path}
+            lessonData={lesson}
+          />
         )}
       </ContentSection>
 

--- a/src/components/LessonButton/LessonButton.js
+++ b/src/components/LessonButton/LessonButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {graphql, StaticQuery} from 'gatsby';
 import PropTypes from 'prop-types';
+import {useLastLessonContext} from '../../providers/LastLessonProvider';
 import analyticsEventHandler from '../../utils/analyticsEventHandler';
 import './LessonButton.scss';
 
@@ -15,24 +16,36 @@ const handleEventClick = path => {
 export const PrimitiveLessonButton = ({
   path,
   onClick = handleEventClick,
-  children
-}) => (
-  <a
-    href={path}
-    className="LessonButton-link"
-    rel="noopener noreferrer"
-    target="_blank"
-    onClick={() => onClick(path)}
-  >
-    {children}
-  </a>
-);
+  children,
+  lessonData
+}) => {
+  const {setLastLessonVisited} = useLastLessonContext();
 
-export const PureLessonButton = ({path, data, defaultTab}) => {
+  return (
+    <a
+      href={path}
+      className="LessonButton-link"
+      rel="noopener noreferrer"
+      target="_blank"
+      onClick={() => {
+        if (lessonData) setLastLessonVisited(lessonData);
+        onClick(path);
+      }}
+    >
+      {children}
+    </a>
+  );
+};
+
+export const PureLessonButton = ({path, data, defaultTab, ...props}) => {
   const {repoOwner} = data.site.siteMetadata;
   const fullPath = `https://codesandbox.io/s/github/${repoOwner}/awesome-learning-exercises/tree/master/${path}?fontsize=14&previewwindow=${defaultTab}`;
   return (
-    <PrimitiveLessonButton path={fullPath}>
+    <PrimitiveLessonButton
+      path={fullPath}
+      onClick={handleEventClick}
+      {...props}
+    >
       Click here to start your exercises!
     </PrimitiveLessonButton>
   );
@@ -68,4 +81,5 @@ PureLessonButton.defaultProps = {
   repoOwner: 'wayfair',
   onClick() {}
 };
+
 export default LessonButton;

--- a/src/components/LessonButton/LessonButton.test.js
+++ b/src/components/LessonButton/LessonButton.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import {PureLessonButton} from './LessonButton';
+import LastLessonProvider from '../../providers/LastLessonProvider';
 
 describe('LessonButton', () => {
   const props = {
@@ -17,7 +18,11 @@ describe('LessonButton', () => {
   };
 
   it('creates a link with the right codesandbox url', () => {
-    const {getByText} = render(<PureLessonButton {...props} />);
+    const {getByText} = render(
+      <LastLessonProvider>
+        <PureLessonButton {...props} />
+      </LastLessonProvider>
+    );
     expect(getByText(/click here/i).href).toBe(
       'https://codesandbox.io/s/github/wayfair/awesome-learning-exercises/tree/master/data-types/objects?fontsize=14&previewwindow=tests'
     );

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,16 +1,17 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Link } from "gatsby";
-import cx from "classnames";
-import "./Link.scss";
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Link} from 'gatsby';
+import cx from 'classnames';
+import {useLastLessonContext} from '../../providers/LastLessonProvider';
+import './Link.scss';
 
 const LINK_VARIATIONS = [
-  "primary",
-  "secondary",
-  "tertiary",
-  "tertiaryAlt",
-  "tertiaryAltInverse",
-  "pill"
+  'primary',
+  'secondary',
+  'tertiary',
+  'tertiaryAlt',
+  'tertiaryAltInverse',
+  'pill'
 ];
 
 const StyledLink = ({
@@ -20,23 +21,33 @@ const StyledLink = ({
   isBlock,
   isButton,
   isActive,
-  isExternal
+  isExternal,
+  lessonData
 }) => {
-  const className = cx("Link", {
-    "is-button": isButton,
-    "is-block": isBlock,
+  const className = cx('Link', {
+    'is-button': isButton,
+    'is-block': isBlock,
     [`Link--${variation}`]: variation && !isButton
   });
+  const {setLastLessonVisited} = useLastLessonContext();
+
+  const clickHandler = () => setLastLessonVisited(lessonData);
 
   return isExternal ? (
-    <a className={className} href={path} target="_blank">
+    <a
+      className={className}
+      href={path}
+      target="_blank"
+      onClick={lessonData && clickHandler}
+    >
       {children}
     </a>
   ) : (
     <Link
       className={className}
       to={path}
-      activeClassName={isActive ? "is-active" : ""}
+      activeClassName={isActive ? 'is-active' : ''}
+      onClick={lessonData && clickHandler}
     >
       {children}
     </Link>

--- a/src/hooks/useStorage.js
+++ b/src/hooks/useStorage.js
@@ -1,0 +1,36 @@
+import {useState} from 'react';
+
+const getStore = (storageType, key) => {
+  const lessonStorage = JSON.parse(storageType.getItem(key)) || {};
+  return lessonStorage[key];
+};
+
+const setStore = (storageType, value, key) =>
+  storageType.setItem(key, JSON.stringify(value));
+
+const useStorage = (storageType, key, initialValue) => {
+  const [state, setState] = useState(() => {
+    try {
+      const item = getStore(storageType, key);
+      return item || initialValue;
+    } catch (error) {
+      console.error(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = value => {
+    try {
+      const valueToState = value instanceof Function ? value(state) : value;
+
+      setStore(storageType, value, key);
+      setState(valueToState);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return [state, setValue];
+};
+
+export default useStorage;

--- a/src/hooks/useStorage.test.js
+++ b/src/hooks/useStorage.test.js
@@ -1,0 +1,19 @@
+import {useState} from 'react';
+import useStorage from './useStorage';
+
+jest.mock('react');
+useState.mockImplementation(func => [func(), useState]);
+
+const localStorageMock = {
+  getItem: str => JSON.stringify({[str]: 'value'}),
+  setItem: (str, json) => ({[str]: JSON.parse(json)})
+};
+
+describe('.useStorage', () => {
+  it('should set the value', () => {
+    const [state, setValue] = useStorage(localStorageMock, 'key', 'value');
+
+    expect(state).toBe('value');
+    expect(typeof setValue).toBe('function');
+  });
+});

--- a/src/providers/LastLessonProvider.js
+++ b/src/providers/LastLessonProvider.js
@@ -1,0 +1,28 @@
+import React, {useContext} from 'react';
+import PropTypes from 'prop-types';
+import useStorage from '../hooks/useStorage';
+
+export const LastLessonContext = React.createContext();
+export const useLastLessonContext = () => useContext(LastLessonContext);
+
+const LastLessonProvider = ({children}) => {
+  const [lastLessonVisited, setLastLessonVisited] = useStorage(
+    localStorage,
+    'lastLessonVisited',
+    ''
+  );
+
+  return (
+    <LastLessonContext.Provider
+      value={{lastLessonVisited, setLastLessonVisited}}
+    >
+      {children}
+    </LastLessonContext.Provider>
+  );
+};
+
+LastLessonProvider.propTypes = {
+  children: PropTypes.node
+};
+
+export default LastLessonProvider;

--- a/src/providers/LastLessonProvider.test.js
+++ b/src/providers/LastLessonProvider.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import LastLessonProvider from './LastLessonProvider';
+import useStorage from '../hooks/useStorage';
+
+jest.mock('../hooks/useStorage', () =>
+  jest.fn().mockImplementation(value => [value, () => {}])
+);
+
+beforeEach(() => {
+  useStorage.mockClear();
+});
+
+const provider = props =>
+  render(<LastLessonProvider {...props}>hello</LastLessonProvider>);
+
+describe('LastLessonProvider', () => {
+  it('should be defined', () => {
+    expect(LastLessonProvider).toBeDefined();
+  });
+
+  describe('.useStorage', () => {
+    it('should be called with the lessonData', () => {
+      provider({lastLessonVisited: 'lesson'});
+
+      expect(useStorage.mock.calls[0]).toEqual([
+        localStorage,
+        'lastLessonVisited',
+        ''
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Added a useStorage hook and LastLessonProvider/Context to track the last lesson attended via local (or session) storage.

Whenever the snackbar notifications are done, we can implement this on the homepage or any other place.

I've wrapped the whole app in the provider, so you can use the custom `useLastLessonContext` hook to set or get the localStorage.

Lesson data will be added to localStorage as an object. See screenshot below:
![image](https://user-images.githubusercontent.com/20415276/66255774-02335d80-e788-11e9-9c3b-5d5c22902660.png)


## Related Issues

Fixes #35 
