### PR TITLE
Remove max-width wrapper from homepage

### DIFF
--- a/src/components/Landing/Landing.js
+++ b/src/components/Landing/Landing.js
@@ -38,14 +38,14 @@ const Landing = ({ courseEdges }) => (
   <div className="Landing">
     <div className="Landing-heroWrapper">
       <div className="Landing-titleWrapper">
-        <SectionTitle  mb="16px" >Learn JavaScript and Front-End Fundamentals.</SectionTitle>
+        <SectionTitle mb="16px" >Learn JavaScript and Front-End Fundamentals.</SectionTitle>
         <Text fontSize="xl" >At your own pace.</Text>
       </div>
       <div className="Landing-courseWrapper">
         <Carousel items={(
-          courseEdges.map(({node}) => {
+          courseEdges.map(({ node }) => {
             const { id, frontmatter, fields } = node;
-            const {title} = frontmatter;
+            const { title } = frontmatter;
             return {
               id,
               title,

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -5,8 +5,5 @@
   &--fullBleed {
     padding: 0;
     max-width: 100%;
-    @media (min-width: 900px){
-      max-width: 80%;
-    }
   }
 }


### PR DESCRIPTION
## Description
This PR removes the max width media query on the home page which was creating a large whitespace gap on screens wider than 960px.

## Related Issues
closes #144