### PR TITLE
Add Toast component to storybook, refactor toast CSS

### DIFF
--- a/src/components/shared/Toast/README.md
+++ b/src/components/shared/Toast/README.md
@@ -1,0 +1,11 @@
+
+The `Toast` component is a non modal, unobtrusive window element used to display brief, auto-expiring windows of information to a user. This toast comes in 4 levels of messaging, each reflected with a different color and icon.
+
+## Props
+
+The following props may be passed to configure the Toast/
+
+| name              | type                                             | description                                      | required |
+| ----------------- | ------------------------------------------------ | ------------------------------------------------ | -------- |
+| **type**          | `oneOf(['info', 'success', 'warning', 'error'])` | The type of toast rendered                       |  `yes`   |
+| **message**       | `text`                                           | The text rendered inside the toast               |  `yes`   |

--- a/src/components/shared/Toast/Toast.js
+++ b/src/components/shared/Toast/Toast.js
@@ -11,7 +11,7 @@ function ToastTypePropError(message) {
 }
 
 // Strongly validates passed type prop to Toast component
-function typeValidation(type){
+function typeValidation(type) {
   const acceptableProps = ['info', 'success', 'warning', 'error'];
   if (acceptableProps.indexOf(type) === -1) {
     const message = `Value '${type}' passed to Toast component in type prop is not valid. Should be 'info', 'success', 'warning' or 'error'`
@@ -23,22 +23,22 @@ function typeValidation(type){
 /* Reusable Toast component
   @prop type: string that can be of value 'info', 'success', 'warning' or 'error'
   @prop message: string used to inform the user of some event
-  Usage example: 
+  Usage example:
                   <Toast type="success" message="Updated member status" />
 */
-export default function Toast(props){
-  const {message, type} = props;
+export default function Toast(props) {
+  const { message, type } = props;
   typeValidation(type)
 
   const [opened, setOpened] = useState(true);
-  const [animationClass, setAnimationClass] = useState('opening-animation')
+  const [animationClass, setAnimationClass] = useState('Toast-openingAnimation')
 
   function closeToast() {
     setTimeout(() => setOpened(false), 500);
-    setAnimationClass('closing-animation')
+    setAnimationClass('Toast-closingAnimation')
   }
 
-  function typeIcon(type){
+  function typeIcon(type) {
     const iconsNames = {
       error: 'forbidden',
       info: 'info',
@@ -51,29 +51,28 @@ export default function Toast(props){
 
   return (
     <>
-    {opened &&
-      <div role="dialog" className={`${animationClass} toast-container toast-${type}`}>
-        <div className="left-corner">
-          <Icon
-            icon={getIcon(typeIcon(type))}
-            className={`toast-icon-${type}`}
-          />
-          <span className={`toast-text toast-text-${type}`}>
-            {type.charAt(0).toUpperCase() + type.slice(1)}: {message}
-          </span>
-        </div>
-        <div className="right-corner">
-          <button className="close-toast" aria-label="Close Dialog" onClick={closeToast}>
-            <Icon icon={getIcon('close')} />
+      {opened &&
+        <div role="dialog" className={`Toast-container ${animationClass} Toast-${type}`}>
+          <div className="Toast-leftCorner">
+            <Icon
+              icon={getIcon(typeIcon(type))}
+            />
+            <p className={`Toast-text Toast-text--${type}`}>
+              {type.charAt(0).toUpperCase() + type.slice(1)}: {message}
+            </p>
+          </div>
+          <button aria-label="Close Dialog" onClick={closeToast}>
+            <Icon cssClasses="Toast-closeButton" icon={getIcon('close')} />
           </button>
         </div>
-      </div>
-    }
+      }
     </>
   );
 }
 
 Toast.propTypes = {
+  /** This is what the component renders, can take a string */
   message: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(['info', 'success', 'warning', 'error'])
+  /** This is the warning level of the toast */
+  type: PropTypes.oneOf(['info', 'success', 'warning', 'error']).isRequired
 };

--- a/src/components/shared/Toast/Toast.scss
+++ b/src/components/shared/Toast/Toast.scss
@@ -1,148 +1,68 @@
-
-.toast-container {
-    border: 1px solid;
-    border-radius: 5px;
-    bottom: 5vh;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding-right: 1.5vw;
-    position: fixed;
-    z-index: 999;
-
-    @media screen and (max-width: 1199px){
-        height: auto;
-        padding-bottom: 2vh;
-        padding-left: 3.5vw;
-        padding-top: 2vh;
-        width: 95%;
+.Toast {
+    &-container {
+        border: 1px solid;
+        border-radius: 5px;
+        bottom: $spacing--medium;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: $spacing--medium;
+        position: fixed;
+        z-index: 999;
         left: 2.5%;
     }
 
-    @media screen and (min-width: 1200px){
-        height: 10vh;
-        padding-left: 2vw;
-        padding-top: 3.5vh;
-        right: 2vw;
-        width: 32vw;
-    }
-
-    .left-corner {
+    &-leftCorner {
         display: flex;
         flex-direction: row;
-        .toast-text{
-            @media screen and (max-width: 355px){
-                font-size: 85%
-            }
-            @media screen and (min-width: 600px) and (max-width: 1199px){
-                font-size: 170%;
-                margin-top: 1%;
-            }
-            font-size: 100%;
-            font-weight: bolder;
-            margin-left: 1vw;
-        }
+        align-items: center;
+    }
 
-        svg {
-            @media screen and (max-width: 1199px){
-                margin-top: -7px;
-            }
-            @media screen and (min-width: 1200px){
-                margin-top: -6%;
-            }
-            height: auto;
-            width: 10%;
+    &-text {
+        font-weight: bolder;
+        margin: 0 $spacing--medium;
+        max-width: 90%;
+        @media screen and (max-width: 355px){
+            font-size: 85%
         }
     }
 
-    .right-corner {
-        @media screen and (max-width: 1199px){
-            margin-right: 3.25vw;
-        }
-        button.close-toast {
-            margin-top: 0.6vh;
-            width: 1.1vw;
-            height: 1.1vw;
-            min-width: 15px;
-            min-height: 15px;
-            svg {
-                width: 100%;
-                height: auto;
-                fill: #a1a1a1;
-                opacity: 0.6;
-            }
-            svg:hover {
-                opacity: 0.8;
-                fill: #808080;
-            }
-            @media screen and (min-width: 600px) and (max-width: 1199px){
-                padding-top: 20%;
-                width: 30px;
-                height: 30px;
-            }
-        }
-        button.close-toast:active {
-            outline: none;
-        }
+    &-closeButton {
+        cursor: pointer;
+        max-height: 20px;
     }
-}
 
+    &-openingAnimation {
+        animation-fill-mode: forwards;
+        animation-name: openingToast;
+        animation-duration: 0.75s;
+    }
 
-.toast-container.toast-error {
-    background-color: #ebc8c6;
-    border-color: #b28f8d;
-    .left-corner .toast-text-error {
-        color: #9c3a37;
+    &-closing-animation {
+        animation-fill-mode: forwards;
+        animation-name: closingToast;
+        animation-duration: 0.50s;
     }
-    .left-corner .toast-icon-error {
-        fill: #9c3a37;
-    }
-}
 
-.toast-container.toast-info {
-    background-color: #cbe8f6;
-    border-color: #a2b8c3;
-    .left-corner .toast-text-info {
-        color: #608397
+    &-error {
+        background-color: #ebc8c6;
+        border-color: #b28f8d;
     }
-    .left-corner .toast-icon-info {
-        fill: #608397;
-    }
-}
 
-.toast-container.toast-success {
-    background-color: #def2d6;
-    border-color: #b9c8b5;
-    .left-corner .toast-text-success {
-        color: #52664a
+    &-info {
+        background-color: #cbe8f6;
+        border-color: #a2b8c3;
     }
-    .left-corner .toast-icon-success {
-        fill: #52664a;
+
+    &-success {
+        background-color: #def2d6;
+        border-color: #b9c8b5;
     }
-}
 
-.toast-container.toast-warning {
-    background-color: #fff0cf;
-    border-color: #d1cead;
-    .left-corner .toast-text-warning {
-        color: #7a704d
+    &-warning {
+        background-color: #fff0cf;
+        border-color: #d1cead;
     }
-    .left-corner .toast-icon-warning {
-        fill: #7a704d;
-    }
-}
-
-
-.opening-animation {
-    animation-fill-mode: forwards;
-    animation-name: openingToast;
-    animation-duration: 0.75s;
-}
-
-.closing-animation {
-    animation-fill-mode: forwards;
-    animation-name: closingToast;
-    animation-duration: 0.50s;
 }
 
 @keyframes openingToast {
@@ -161,7 +81,7 @@
         opacity: 1;
         transform: translate3d(0, 0, 0);
       }
-    
+
     to {
         opacity: 0;
         transform: translate3d(0, 100%, 0);

--- a/src/components/shared/Toast/Toast.stories.js
+++ b/src/components/shared/Toast/Toast.stories.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import Toast from './Toast'
+import ToastReadme from './README.md'
+
+const toastType = {
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  error: 'error'
+}
+
+const messageLength = {
+  shortMessage: "This is a short toast",
+  longMessage: "This is a super long message with tons of text, but it shows how a toast responds to long messages"
+}
+
+const stories = storiesOf('Shared.Toast', module);
+
+stories
+  .addDecorator(withKnobs)
+  .addParameters({
+    readme: {
+      sidebar: ToastReadme,
+    },
+  })
+  .add(
+    'basic',
+    () =>
+      <Toast
+        type={select('type', toastType, 'info')}
+        message={select('message length', messageLength)}
+      />
+  )

--- a/src/components/shared/Toast/Toast.test.js
+++ b/src/components/shared/Toast/Toast.test.js
@@ -42,22 +42,6 @@ describe('Toast', () => {
     };
     expect(renderList).toThrow(error);
   });
-
-  it('complies with expected behavior', () => {
-    const wrapper = Enzyme.shallow(<Toast type='info' message='User pending action' />);;
-
-    expect(wrapper.find('.toast-container').exists()).toBeTruthy();
-    expect(wrapper.find('.opening-animation').exists()).toBeTruthy();
-    expect(wrapper.find('.closing-animation').exists()).toBeFalsy();
-    expect(wrapper.find('.toast-text').exists()).toBeTruthy();
-    expect(wrapper.find('.toast-icon-info').exists()).toBeTruthy();
-
-    wrapper.find('.close-toast').props().onClick();
-
-    expect(wrapper.find('.closing-animation').exists()).toBeTruthy();
-    expect(wrapper.find('.opening-animation').exists()).toBeFalsy();
-    
-  })
 });
 
 


### PR DESCRIPTION
## Description
The new shared toast component was not in our storybook implementation. While adding the toast, I realized the css did not follow our general SUIT standards and contained some unnecessary styling. 

## Changes
1. Create a story and readme for the toast component
2. Refactor CSS to match our SUIT standards
3. Remove unnecessary CSS
4. Restyle some elements of the component
5. Remove test that relied on CSS classes