### PR TITLE
Spacing fix for CourseCards

### DIFF
--- a/src/components/CourseCard/CourseCard.scss
+++ b/src/components/CourseCard/CourseCard.scss
@@ -2,7 +2,8 @@
 @import '../../assets/scss/mixins';
 
 .CourseCard {
-  @include margin(2, 1.3, 2, 1.3);
+  margin: $spacing--xLarge 0;
+  padding: 0 $spacing--xLarge;
   position: relative;
   counter-increment: listItemCount;
   margin-bottom: $spacing--small;
@@ -14,7 +15,7 @@
     font-size: 6em;
     z-index: -1;
     line-height: 50px;
-    top: -15px;
+    top: 0;
     left: -35px;
   }
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixing the spacing of numbers on the course pages 

Before
![image](https://user-images.githubusercontent.com/1457710/67909645-4f6fd880-fb56-11e9-9684-50f9d3f697d7.png)

After
![image](https://user-images.githubusercontent.com/1457710/67909701-8c3bcf80-fb56-11e9-9aa2-f8e649116322.png)
