### PR TITLE
Fixing a few broken links

### DIFF
--- a/content/courses/SOLID.md
+++ b/content/courses/SOLID.md
@@ -2,7 +2,7 @@
 title: SOLID Principles
 template: "course"
 draft: false
-slug: "/courses/Solid/"
+slug: "/courses/SOLID/"
 category: "Object-Oriented Design"
 tags:
 - "Usability"
@@ -10,10 +10,10 @@ tags:
 - "OOP"
 description: Familiarize yourself with the SOLID Design Principles and put them into practice. In the first lesson, walk through a conversational multiple-choice "quiz" (great for absolute beginners), and in the second, rewrite principle-violating code in line with the principles. This course assumes you have basic familiarity with Java, though by no means an expert understanding.
 lessons:
-- link: "solid-part-1"
+- link: "SOLID-part-1"
   title: SOLID Principles Part 1
   description: This lesson serves as an introduction to the SOLID Design Principles, going over when and how to implement them, in a multiple-choice quiz format. The tone is conversational- you will be guided towards why an answer is correct or incorrect as you select the different options.
-- link: "solid-part-2"
+- link: "SOLID-part-2"
   title: SOLID Principles Part 2
   description: Put your new SOLID knowledge to the test as you rewrite principle-violating code so it is in line with the principles.
 ---

--- a/content/lessons/functional-programming/immutability.md
+++ b/content/lessons/functional-programming/immutability.md
@@ -3,7 +3,7 @@ title: Immutability
 template: lesson
 draft: false
 slug: /courses/Functional-Programming/immutability
-course: Functional Programming
+course: Functional-Programming
 tags:
   - "Usability"
   - "Maintainability"

--- a/content/lessons/solid/solid-part-1.md
+++ b/content/lessons/solid/solid-part-1.md
@@ -2,7 +2,7 @@
 title: SOLID Principles Part 1
 template: lesson
 draft: false
-slug: /courses/Solid/solid-part-1
+slug: /courses/SOLID/SOLID-part-1
 course: SOLID
 tags:
 - Usability

--- a/content/lessons/solid/solid-part-2.md
+++ b/content/lessons/solid/solid-part-2.md
@@ -2,7 +2,7 @@
 title: SOLID Principles Part 2
 template: lesson
 draft: false
-slug: /courses/Solid/solid-part-2
+slug: /courses/SOLID/SOLID-part-2
 course: SOLID
 tags:
 - Usability

--- a/src/templates/not-found-template.js
+++ b/src/templates/not-found-template.js
@@ -16,7 +16,7 @@ const NotFoundTemplate = () => (
           You just hit a route that doesn't exist.
         </Typography>
         <Box my={4} textAlign="center">
-          <Button variant="contained" color="secondary" href={'/'}>
+          <Button variant="contained" color="secondary" href={'/awesome-learning/'}>
             Go back home
           </Button>
         </Box>


### PR DESCRIPTION
## Description

Right now there are a few routes which mismatch with their respective Gatsby templates and so cause 404s:
1. Clicking into a lesson from the Functional Programming course, the "return to Functional Programming" link directs to `/courses/${course}/` but since the course property in the md file is Functional Programming rather than Functional-Programming, it returns a 404.
2. Very similarly, since the SOLID lessons refer to course SOLID, the link breaks since the lesson actually lives on /courses/Solid - I tried to just mostly standardize usage of the acronym in all caps.
3. The 404 page "Go back home" button directs to `/` which is a Github page that doesn't exist. Instead it should direct to the awesome-learning home page.

## Related Issues
None